### PR TITLE
Codesmon/SetInternalServerErrorOnUnknownError

### DIFF
--- a/src/handler/proxy.go
+++ b/src/handler/proxy.go
@@ -96,7 +96,8 @@ func handleError(response http.ResponseWriter, request *http.Request, err error)
 	status_code, err := strconv.ParseInt(response.Header().Get(constants.HEADER_STATUS_CODE), 10, 32)
 	if err != nil {
 		log.Errorln("Failed to parse status code", err)
-		status_code = 0
+		status_code = 500
+		response.WriteHeader(http.StatusInternalServerError)
 	}
 
 	metricAttributes := []attribute.KeyValue{

--- a/src/handler/proxy.go
+++ b/src/handler/proxy.go
@@ -95,7 +95,7 @@ func handleError(response http.ResponseWriter, request *http.Request, err error)
 	// requests_total{target_host, method, path, user_agent, status_code}
 	status_code, err := strconv.ParseInt(response.Header().Get(constants.HEADER_STATUS_CODE), 10, 32)
 	if err != nil {
-		log.Errorln("Failed to parse status code", err)
+		log.Errorln("Failed to parse status code, setting to 500", err)
 		status_code = 500
 		response.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
When handling an error, if there is no HTTP Status Code in the response (maybe there is no response as the call failed completely), set the Status to 500 to let the caller know that it failed.