### PR TITLE
Retry initialization + return 503 on failure to connect

### DIFF
--- a/src/constants/constants.go
+++ b/src/constants/constants.go
@@ -47,6 +47,7 @@ const (
 	BYTES_2KB = 2048 // 2K
 
 	// Time
+	TIME_5_SECONDS = time.Second * 5
 	TIME_1_MINUTES = time.Minute * 1
 	TIME_5_MINUTES = time.Minute * 5
 

--- a/src/handler/fail_request.go
+++ b/src/handler/fail_request.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"aad-auth-proxy/constants"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// Fail request
+func FailRequest(w http.ResponseWriter, r *http.Request, statusCode int, errorCode string, ctx context.Context, err error) {
+	_, span := otel.Tracer(constants.SERVICE_TELEMETRY_KEY).Start(ctx, "failRequest")
+	defer span.End()
+
+	errorMessage := err.Error()
+	requestId := r.Header.Get(constants.HEADER_REQUEST_ID)
+
+	span.SetAttributes(
+		attribute.Int("response.status_code", statusCode),
+		attribute.String("response.request_id", requestId),
+		attribute.String("response.error.code", errorCode),
+		attribute.String("response.error.message", errorMessage),
+	)
+	span.SetStatus(codes.Error, "failed to forward request")
+
+	w.WriteHeader(statusCode)
+	w.Header().Add(constants.HEADER_CONTENT_TYPE, "application/json")
+	w.Header().Add(constants.HEADER_STATUS_CODE, strconv.Itoa(statusCode))
+	resp := make(map[string]string)
+	resp[constants.ERROR_PROPERTY_CODE] = errorCode
+	resp[constants.ERROR_PROPERTY_MESSAGE] = errorMessage
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	w.Write(jsonResp)
+}


### PR DESCRIPTION
1. During initialization wait for valid handler.
2. If unable to establish connection with remote host, return back 503 to caller.