### PR TITLE
#42 Fixes the invalid Helm chart API version

### DIFF
--- a/deploy/chart/aad-auth-proxy/Chart-template.yaml
+++ b/deploy/chart/aad-auth-proxy/Chart-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: aad-auth-proxy
 description: A Helm chart for deploying a forward proxy which authenticates requests using Azure AAD.
 


### PR DESCRIPTION
According to [official Helm v3 documentation](https://helm.sh/docs/topics/charts/#the-apiversion-field) `apiVersion: v3` is invalid. It must be either v1 or v2.